### PR TITLE
Rename framework to Sparrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Sparrow - Minimal Python HTTP Framework
+
+Sparrow is a minimal Python framework that demonstrates core concepts of a web framework.
+It aims to show what happens when an HTTP request arrives and how the framework dispatches it to a route handler.
+
+## Features
+
+- Routing with path parameters
+- Middleware support
+- Request and response abstraction
+- JSON body parsing and responses
+- Simple server startup
+
+## Example Usage
+
+Run the provided example server:
+
+```bash
+python example_server.py
+```
+
+Then open `http://localhost:8080/hello` in your browser or use `curl`:
+
+```bash
+curl http://localhost:8080/hello
+```
+
+See `example_server.py` for more routes and usage examples.

--- a/example_server.py
+++ b/example_server.py
@@ -1,0 +1,31 @@
+from sparrow import Sparrow
+
+app = Sparrow()
+
+
+# Middleware example
+@app.use
+def logger(req, res, next_func):
+    print(f"{req.method} {req.path}")
+    next_func()
+
+
+# Route handlers
+@app.get("/hello")
+def hello(req, res):
+    res.send("Hello, world!")
+
+
+@app.get("/users/:user_id")
+def get_user(req, res):
+    user_id = req.params.get("user_id")
+    res.json({"user": user_id})
+
+
+@app.post("/echo")
+def echo(req, res):
+    res.json({"received": req.body})
+
+
+if __name__ == "__main__":
+    app.listen(port=8080)

--- a/sparrow/__init__.py
+++ b/sparrow/__init__.py
@@ -1,0 +1,3 @@
+from .app import Sparrow
+
+__all__ = ["Sparrow"]

--- a/sparrow/app.py
+++ b/sparrow/app.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Callable, List
+
+from .request import Request
+from .response import Response
+from .router import Router
+
+Middleware = Callable[[Request, Response, Callable[[], None]], None]
+Handler = Callable[[Request, Response], None]
+
+
+class Sparrow:
+    """A minimal HTTP framework to demonstrate request handling."""
+
+    def __init__(self) -> None:
+        self.router = Router()
+        self.middleware: List[Middleware] = []
+
+    # Route decorators
+    def route(self, path: str, methods: List[str]) -> Callable[[Handler], Handler]:
+        def decorator(func: Handler) -> Handler:
+            for method in methods:
+                self.router.add_route(method.upper(), path, func)
+            return func
+        return decorator
+
+    def get(self, path: str) -> Callable[[Handler], Handler]:
+        return self.route(path, ["GET"])
+
+    def post(self, path: str) -> Callable[[Handler], Handler]:
+        return self.route(path, ["POST"])
+
+    def use(self, func: Middleware) -> None:
+        self.middleware.append(func)
+
+    def _handle(self, handler: BaseHTTPRequestHandler) -> None:
+        req = Request(handler)
+        res = Response(handler)
+        index = 0
+
+        def next_middleware() -> None:
+            nonlocal index
+            if index < len(self.middleware):
+                current = self.middleware[index]
+                index += 1
+                current(req, res, next_middleware)
+            else:
+                route_handler, params = self.router.match(req.method, req.path)
+                if route_handler:
+                    req.params = params
+                    route_handler(req, res)
+                else:
+                    res.send("Not Found", status=404)
+
+        next_middleware()
+
+    def listen(self, host: str = "127.0.0.1", port: int = 8000) -> None:
+        app = self
+
+        class RequestHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                app._handle(self)
+
+            def do_POST(self) -> None:
+                app._handle(self)
+
+            def log_message(self, format: str, *args) -> None:  # pragma: no cover
+                return
+
+        httpd = HTTPServer((host, port), RequestHandler)
+        print(f"Serving on http://{host}:{port}")
+        httpd.serve_forever()

--- a/sparrow/request.py
+++ b/sparrow/request.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urlparse
+
+
+class Request:
+    """HTTP request wrapper."""
+
+    def __init__(self, handler: BaseHTTPRequestHandler) -> None:
+        self.method: str = handler.command
+        self.headers = handler.headers
+        parsed = urlparse(handler.path)
+        self.path: str = parsed.path
+        self.query: Dict[str, Any] = {k: v[0] if len(v) == 1 else v for k, v in parse_qs(parsed.query).items()}
+        self.body: Optional[Any] = self._read_body(handler)
+        self.params: Dict[str, str] = {}
+
+    def _read_body(self, handler: BaseHTTPRequestHandler) -> Optional[Any]:
+        length = int(handler.headers.get('Content-Length', 0))
+        if length == 0:
+            return None
+        data = handler.rfile.read(length)
+        content_type = handler.headers.get('Content-Type', '')
+        if 'application/json' in content_type:
+            try:
+                return json.loads(data)
+            except json.JSONDecodeError:
+                return None
+        return data.decode('utf-8')

--- a/sparrow/response.py
+++ b/sparrow/response.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler
+from typing import Any, Dict
+
+
+class Response:
+    """HTTP response helper."""
+
+    def __init__(self, handler: BaseHTTPRequestHandler) -> None:
+        self._handler = handler
+        self._sent = False
+
+    def send(self, body: Any, status: int = 200, headers: Dict[str, str] | None = None) -> None:
+        if self._sent:
+            return
+        self._handler.send_response(status)
+        headers = headers or {}
+        if isinstance(body, (dict, list)):
+            headers.setdefault('Content-Type', 'application/json')
+            body = json.dumps(body)
+        for name, value in headers.items():
+            self._handler.send_header(name, value)
+        if isinstance(body, str):
+            body = body.encode('utf-8')
+        self._handler.send_header('Content-Length', str(len(body)))
+        self._handler.end_headers()
+        self._handler.wfile.write(body)
+        self._sent = True
+
+    def json(self, obj: Any, status: int = 200, headers: Dict[str, str] | None = None) -> None:
+        headers = headers or {}
+        headers.setdefault('Content-Type', 'application/json')
+        self.send(json.dumps(obj), status=status, headers=headers)

--- a/sparrow/router.py
+++ b/sparrow/router.py
@@ -1,0 +1,31 @@
+from typing import Callable, Dict, List, Optional, Tuple
+
+
+class Router:
+    """Simple route registry and matcher."""
+
+    def __init__(self) -> None:
+        self.routes: List[Tuple[str, str, Callable]] = []
+
+    def add_route(self, method: str, path: str, handler: Callable) -> None:
+        self.routes.append((method.upper(), path, handler))
+
+    def match(self, method: str, path: str) -> Tuple[Optional[Callable], Dict[str, str]]:
+        for route_method, route_path, handler in self.routes:
+            params = self._match_path(route_path, path)
+            if route_method == method and params is not None:
+                return handler, params
+        return None, {}
+
+    def _match_path(self, route_path: str, request_path: str) -> Optional[Dict[str, str]]:
+        route_parts = route_path.strip('/').split('/')
+        request_parts = request_path.strip('/').split('/')
+        if len(route_parts) != len(request_parts):
+            return None
+        params: Dict[str, str] = {}
+        for route_part, req_part in zip(route_parts, request_parts):
+            if route_part.startswith(':'):
+                params[route_part[1:]] = req_part
+            elif route_part != req_part:
+                return None
+        return params

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,64 @@
+import http.client
+import threading
+import time
+import unittest
+
+from sparrow import Sparrow
+
+app = Sparrow()
+
+@app.get('/test')
+def test_handler(req, res):
+    res.send('ok')
+
+@app.post('/mirror')
+def mirror(req, res):
+    res.json({'data': req.body})
+
+
+def start_server():
+    app.listen(host='127.0.0.1', port=9090)
+
+
+def wait_for_server(port=9090, timeout=5):
+    for _ in range(timeout * 10):
+        conn = http.client.HTTPConnection('127.0.0.1', port)
+        try:
+            conn.request('GET', '/')
+            conn.getresponse()
+            conn.close()
+            return True
+        except Exception:
+            time.sleep(0.1)
+    return False
+
+
+class ServerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        thread = threading.Thread(target=start_server, daemon=True)
+        thread.start()
+        assert wait_for_server()
+
+    def test_get(self):
+        conn = http.client.HTTPConnection('127.0.0.1', 9090)
+        conn.request('GET', '/test')
+        resp = conn.getresponse()
+        body = resp.read().decode()
+        conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(body, 'ok')
+
+    def test_post_json(self):
+        conn = http.client.HTTPConnection('127.0.0.1', 9090)
+        headers = {'Content-Type': 'application/json'}
+        conn.request('POST', '/mirror', body='{"foo": "bar"}', headers=headers)
+        resp = conn.getresponse()
+        data = resp.read().decode()
+        conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertIn('"foo": "bar"', data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- rename `miniframework` package to `sparrow`
- update class name from `MiniFramework` to `Sparrow`
- update example, tests, and docs

## Testing
- `python -m unittest discover -s tests -v`
