### PR TITLE
Add detailed challenges and progress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ curl http://localhost:8080/hello
 ```
 
 See `example_server.py` for more routes and usage examples.
+
+## Coding Challenges
+
+Several core functions have been replaced with TODOs. See the `challenges` directory for instructions on implementing the router, request parsing, response helpers and the main application logic.
+
+## Running Tests
+
+All exercises are backed by unit tests using `pytest`. Install the dependency and run the test suite with:
+
+```bash
+pip install pytest
+python -m pytest -v
+```
+
+The tests print helpful messages so you can easily track which portions of the framework you have completed.

--- a/challenges/app/README.md
+++ b/challenges/app/README.md
@@ -1,0 +1,18 @@
+# Application Challenge
+
+Two key methods in `sparrow/app.py` are intentionally incomplete.
+
+## Goal
+
+Wire together middleware execution, route dispatching and server start up.
+
+### Tasks
+
+1. **_handle** - create `Request` and `Response` instances, execute registered middleware in order and finally invoke the matched route handler. If no route matches, send a 404 response.
+2. **listen** - create an `HTTPServer` using a custom `BaseHTTPRequestHandler` subclass. Its handler methods should delegate to `_handle` and suppress default logging.
+
+### Example
+
+When complete you should be able to run `example_server.py` and see responses for the registered routes.
+
+Run `pytest` to ensure your implementation works as expected.

--- a/challenges/request/README.md
+++ b/challenges/request/README.md
@@ -1,0 +1,27 @@
+# Request Challenge
+
+Complete the body parsing logic inside `Request._read_body` located in `sparrow/request.py`.
+
+## Goal
+
+Read the raw body from the HTTP handler and expose the parsed value via `Request.body`.
+
+### Tasks
+
+1. Read the body using the `Content-Length` header.
+2. If the `Content-Type` contains `application/json`, decode the text and parse it with `json.loads`. When parsing fails return `None`.
+3. For any other content type simply decode the bytes as UTF-8.
+
+### Example
+
+```python
+headers = {
+    'Content-Length': '13',
+    'Content-Type': 'application/json'
+}
+handler = DummyHandler(body=b'{"a":1}', headers=headers)
+req = Request(handler)
+assert req.body == {"a": 1}
+```
+
+Use the provided tests (`pytest`) to verify your implementation.

--- a/challenges/response/README.md
+++ b/challenges/response/README.md
@@ -1,0 +1,21 @@
+# Response Challenge
+
+Fill in the response helpers defined in `sparrow/response.py`.
+
+## Goal
+
+Provide a simple API for sending HTTP responses from handlers.
+
+### Tasks
+
+1. **send** - write the status line, headers, and body to the underlying `BaseHTTPRequestHandler`. If the body is a dictionary or list, serialize it with `json.dumps` and set `Content-Type` to `application/json`. Strings should be encoded as UTF-8. Prevent multiple calls from sending multiple responses.
+2. **json** - convenience wrapper that serializes the object and delegates to `send`.
+
+### Example
+
+```python
+res.send('hello', status=200)
+res.json({'ok': True})
+```
+
+Run `pytest` when you think you are done.

--- a/challenges/router/README.md
+++ b/challenges/router/README.md
@@ -1,0 +1,29 @@
+# Router Challenge
+
+In this challenge you will build Sparrow's routing system.
+
+## Goal
+
+Implement the three missing methods inside `sparrow/router.py`.
+
+### Tasks
+
+1. **add_route** - store a tuple of `(method, normalized_path, handler)` so routes can be looked up later.
+2. **match** - iterate over registered routes returning the handler and any parameters once a path matches.
+3. **_match_path** - compare route paths against incoming request paths.  Support parameters prefixed with `:` and return them as a dictionary.
+
+### Example
+
+```python
+router = Router()
+
+def hello(req, res):
+    pass
+
+router.add_route('GET', '/hello/:name', hello)
+handler, params = router.match('GET', '/hello/bob')
+assert handler is hello
+assert params == {'name': 'bob'}
+```
+
+Run `pytest` to verify your work once you've completed the implementation.

--- a/sparrow/app.py
+++ b/sparrow/app.py
@@ -36,39 +36,15 @@ class Sparrow:
         self.middleware.append(func)
 
     def _handle(self, handler: BaseHTTPRequestHandler) -> None:
-        req = Request(handler)
-        res = Response(handler)
-        index = 0
-
-        def next_middleware() -> None:
-            nonlocal index
-            if index < len(self.middleware):
-                current = self.middleware[index]
-                index += 1
-                current(req, res, next_middleware)
-            else:
-                route_handler, params = self.router.match(req.method, req.path)
-                if route_handler:
-                    req.params = params
-                    route_handler(req, res)
-                else:
-                    res.send("Not Found", status=404)
-
-        next_middleware()
+        """Handle a single HTTP request."""
+        # TODO: create ``Request`` and ``Response`` objects, run middleware in
+        # order and dispatch to the matched route handler. Send a 404 response
+        # when no route matches.
+        raise NotImplementedError
 
     def listen(self, host: str = "127.0.0.1", port: int = 8000) -> None:
-        app = self
-
-        class RequestHandler(BaseHTTPRequestHandler):
-            def do_GET(self) -> None:
-                app._handle(self)
-
-            def do_POST(self) -> None:
-                app._handle(self)
-
-            def log_message(self, format: str, *args) -> None:  # pragma: no cover
-                return
-
-        httpd = HTTPServer((host, port), RequestHandler)
-        print(f"Serving on http://{host}:{port}")
-        httpd.serve_forever()
+        """Start an HTTP server to serve requests."""
+        # TODO: create an ``HTTPServer`` instance that uses a custom
+        # ``BaseHTTPRequestHandler`` subclass. The handler methods should call
+        # ``_handle`` for each incoming request and suppress default logging.
+        raise NotImplementedError

--- a/sparrow/request.py
+++ b/sparrow/request.py
@@ -19,14 +19,9 @@ class Request:
         self.params: Dict[str, str] = {}
 
     def _read_body(self, handler: BaseHTTPRequestHandler) -> Optional[Any]:
-        length = int(handler.headers.get('Content-Length', 0))
-        if length == 0:
-            return None
-        data = handler.rfile.read(length)
-        content_type = handler.headers.get('Content-Type', '')
-        if 'application/json' in content_type:
-            try:
-                return json.loads(data)
-            except json.JSONDecodeError:
-                return None
-        return data.decode('utf-8')
+        """Read and parse the request body."""
+        # TODO: use the ``Content-Length`` header to read the request body from
+        # ``handler.rfile``. If the content type is JSON, decode and return the
+        # parsed object. Otherwise return the decoded text. If no body is
+        # present, return ``None``.
+        raise NotImplementedError

--- a/sparrow/response.py
+++ b/sparrow/response.py
@@ -13,23 +13,15 @@ class Response:
         self._sent = False
 
     def send(self, body: Any, status: int = 200, headers: Dict[str, str] | None = None) -> None:
-        if self._sent:
-            return
-        self._handler.send_response(status)
-        headers = headers or {}
-        if isinstance(body, (dict, list)):
-            headers.setdefault('Content-Type', 'application/json')
-            body = json.dumps(body)
-        for name, value in headers.items():
-            self._handler.send_header(name, value)
-        if isinstance(body, str):
-            body = body.encode('utf-8')
-        self._handler.send_header('Content-Length', str(len(body)))
-        self._handler.end_headers()
-        self._handler.wfile.write(body)
-        self._sent = True
+        """Send a response to the client."""
+        # TODO: write the HTTP status and headers using ``self._handler``. If
+        # ``body`` is a dict or list, serialize it as JSON and set the
+        # ``Content-Type`` header appropriately. Encode strings as UTF-8 before
+        # writing and ensure the response is only sent once.
+        raise NotImplementedError
 
     def json(self, obj: Any, status: int = 200, headers: Dict[str, str] | None = None) -> None:
-        headers = headers or {}
-        headers.setdefault('Content-Type', 'application/json')
-        self.send(json.dumps(obj), status=status, headers=headers)
+        """Convenience method for sending JSON data."""
+        # TODO: serialize ``obj`` to JSON and call ``send`` with the correct
+        # headers.
+        raise NotImplementedError

--- a/sparrow/router.py
+++ b/sparrow/router.py
@@ -8,24 +8,21 @@ class Router:
         self.routes: List[Tuple[str, str, Callable]] = []
 
     def add_route(self, method: str, path: str, handler: Callable) -> None:
-        self.routes.append((method.upper(), path, handler))
+        """Register a new route."""
+        # TODO: store the method, normalized path and handler so that it can be
+        # matched later in ``match``.
+        raise NotImplementedError
 
     def match(self, method: str, path: str) -> Tuple[Optional[Callable], Dict[str, str]]:
-        for route_method, route_path, handler in self.routes:
-            params = self._match_path(route_path, path)
-            if route_method == method and params is not None:
-                return handler, params
-        return None, {}
+        """Return the first matching handler and extracted parameters."""
+        # TODO: iterate over registered routes and use ``_match_path`` to
+        # determine if the path matches. Return the handler and parameters when
+        # a match is found or ``(None, {})`` otherwise.
+        raise NotImplementedError
 
     def _match_path(self, route_path: str, request_path: str) -> Optional[Dict[str, str]]:
-        route_parts = route_path.strip('/').split('/')
-        request_parts = request_path.strip('/').split('/')
-        if len(route_parts) != len(request_parts):
-            return None
-        params: Dict[str, str] = {}
-        for route_part, req_part in zip(route_parts, request_parts):
-            if route_part.startswith(':'):
-                params[route_part[1:]] = req_part
-            elif route_part != req_part:
-                return None
-        return params
+        """Compare a route path against a request path."""
+        # TODO: split the paths and compare each segment. Support parameters
+        # prefixed with ':' in the route path and return them in a dictionary
+        # when the paths match. Return ``None`` if they do not match.
+        raise NotImplementedError

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,32 @@
+import io
+import unittest
+
+from sparrow.request import Request
+
+
+class DummyHandler:
+    def __init__(self, method='POST', path='/', headers=None, body=b''):
+        self.command = method
+        self.path = path
+        self.headers = headers or {}
+        self.rfile = io.BytesIO(body)
+
+
+class RequestChallengeTests(unittest.TestCase):
+    def test_json_body(self):
+        print("Request JSON body parsing")
+        headers = {'Content-Length': '13', 'Content-Type': 'application/json'}
+        handler = DummyHandler(body=b'{"foo": "bar"}', headers=headers)
+        req = Request(handler)
+        self.assertEqual(req.body, {"foo": "bar"})
+
+    def test_text_body(self):
+        print("Request text body parsing")
+        headers = {'Content-Length': '11', 'Content-Type': 'text/plain'}
+        handler = DummyHandler(body=b'hello world', headers=headers)
+        req = Request(handler)
+        self.assertEqual(req.body, "hello world")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,44 @@
+import io
+import unittest
+
+from sparrow.response import Response
+
+
+class DummyHandler:
+    def __init__(self):
+        self.status = None
+        self.sent_headers = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+
+class ResponseChallengeTests(unittest.TestCase):
+    def test_send_text(self):
+        print("Response send text")
+        handler = DummyHandler()
+        res = Response(handler)
+        res.send("hi")
+        self.assertEqual(handler.status, 200)
+        self.assertEqual(handler.wfile.getvalue().decode(), "hi")
+
+    def test_send_json(self):
+        print("Response send json")
+        handler = DummyHandler()
+        res = Response(handler)
+        res.json({"a": 1})
+        body = handler.wfile.getvalue().decode()
+        headers = dict(handler.sent_headers)
+        self.assertIn("application/json", headers.get("Content-Type", ""))
+        self.assertIn('"a": 1', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,28 @@
+import unittest
+from sparrow.router import Router
+
+
+def dummy(req, res):
+    pass
+
+
+class RouterChallengeTests(unittest.TestCase):
+    def test_static_route(self):
+        print("Router static route test")
+        r = Router()
+        r.add_route('GET', '/foo', dummy)
+        handler, params = r.match('GET', '/foo')
+        self.assertIs(handler, dummy)
+        self.assertEqual(params, {})
+
+    def test_param_route(self):
+        print("Router parameter test")
+        r = Router()
+        r.add_route('GET', '/user/:id', dummy)
+        handler, params = r.match('GET', '/user/42')
+        self.assertIs(handler, dummy)
+        self.assertEqual(params, {'id': '42'})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,11 +36,13 @@ def wait_for_server(port=9090, timeout=5):
 class ServerTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        print("Starting test server")
         thread = threading.Thread(target=start_server, daemon=True)
         thread.start()
         assert wait_for_server()
 
     def test_get(self):
+        print("Server GET request test")
         conn = http.client.HTTPConnection('127.0.0.1', 9090)
         conn.request('GET', '/test')
         resp = conn.getresponse()
@@ -50,6 +52,7 @@ class ServerTests(unittest.TestCase):
         self.assertEqual(body, 'ok')
 
     def test_post_json(self):
+        print("Server POST request test")
         conn = http.client.HTTPConnection('127.0.0.1', 9090)
         headers = {'Content-Type': 'application/json'}
         conn.request('POST', '/mirror', body='{"foo": "bar"}', headers=headers)


### PR DESCRIPTION
## Summary
- expand challenge instructions with examples and task lists
- document how to run the unit tests
- add tests for router, request, and response challenges
- print helpful messages in server test for progress tracking

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*